### PR TITLE
Revert "Move Byrnes' parallel OptSched to main repo (#182)"

### DIFF
--- a/include/opt-sched/Scheduler/lnkd_lst.h
+++ b/include/opt-sched/Scheduler/lnkd_lst.h
@@ -454,7 +454,8 @@ template <class T> void LinkedList<T>::RmvElmnt(const T *const elmnt, bool free)
        crntEntry = crntEntry->GetNext()) {
     if (crntEntry->element == elmnt) {
       // Found.
-
+      //RmvEntry_(crntEntry);
+      
       if (crntEntry == topEntry_) {
         topEntry_ = crntEntry->GetNext();
       }
@@ -471,6 +472,7 @@ template <class T> void LinkedList<T>::RmvElmnt(const T *const elmnt, bool free)
         prevEntry->SetNext(crntEntry->GetNext());
       }
 
+      // 
       if (crntEntry == rtrvEntry_) {
         rtrvEntry_ = prevEntry;
       }
@@ -538,9 +540,7 @@ template <class T> inline T *LinkedList<T>::GetLastElmnt() {
 template <class T> inline T *LinkedList<T>::GetNxtElmnt() {
   if (wasTopRmvd_) {
     rtrvEntry_ = topEntry_;
-    wasTopRmvd_ = false;
   } else {
-    assert(rtrvEntry_ != nullptr);
     rtrvEntry_ = rtrvEntry_->GetNext();
   }
 
@@ -555,11 +555,6 @@ template <class T> inline T *LinkedList<T>::GetNxtElmnt() {
 }
 
 template <class T> inline T *LinkedList<T>::GetPrevElmnt() {
-  if (wasTopRmvd_) {
-    rtrvEntry_ = topEntry_;
-    wasTopRmvd_ = false;
-  }
-  assert(rtrvEntry_ != NULL);
   rtrvEntry_ = rtrvEntry_->GetPrev();
   return rtrvEntry_ == NULL ? NULL : rtrvEntry_->element;
 }
@@ -651,7 +646,6 @@ template <class T> void LinkedList<T>::RmvEntry_(Entry<T> *entry, bool free) {
   if (prevEntry == NULL) {
     assert(entry == topEntry_);
     topEntry_ = nextEntry;
-    wasTopRmvd_ = true; // Flag updates inside RmvEntry on head removal
   } else {
     prevEntry->SetNext(nextEntry);
   }
@@ -660,7 +654,6 @@ template <class T> void LinkedList<T>::RmvEntry_(Entry<T> *entry, bool free) {
   if (nextEntry == NULL) {
     assert(entry == bottomEntry_);
     bottomEntry_ = prevEntry;
-    wasBottomRmvd_ = true; // Flag updates inside RmvEntry on tail removal
   } else {
     nextEntry->SetPrev(prevEntry);
   }
@@ -686,6 +679,7 @@ template <class T> inline void LinkedList<T>::Init_() {
   wasBottomRmvd_ = false;
 }
 
+
 template <class T>
 void LinkedList<T>::CopyList(LinkedList<T> const *const otherLst) {
   assert(LinkedList<T>::elmntCnt_ == 0);
@@ -704,6 +698,20 @@ void LinkedList<T>::CopyList(LinkedList<T> const *const otherLst) {
 
   LinkedList<T>::itrtrReset_ = otherLst->itrtrReset_;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 template <class T> inline T *Queue<T>::ExtractElmnt() {
   if (LinkedList<T>::topEntry_ == NULL)
@@ -780,10 +788,9 @@ KeyedEntry<T, K> *PriorityList<T, K>::InsrtElmnt(T *elmnt, K key,
 
 template <class T, class K>
 inline T *PriorityList<T, K>::ViewNxtPriorityElmnt() {
-  bool rtrvInvalid = LinkedList<T>::itrtrReset_ || LinkedList<T>::wasTopRmvd_;
-  assert(rtrvInvalid || LinkedList<T>::rtrvEntry_ != NULL);
+  assert(LinkedList<T>::itrtrReset_ || LinkedList<T>::rtrvEntry_ != NULL);
 
-  if (rtrvInvalid) {
+  if (LinkedList<T>::itrtrReset_) {
     return LinkedList<T>::topEntry_->element;
   } else {
     return LinkedList<T>::rtrvEntry_->element;
@@ -792,12 +799,10 @@ inline T *PriorityList<T, K>::ViewNxtPriorityElmnt() {
 
 template <class T, class K>
 inline T *PriorityList<T, K>::GetNxtPriorityElmnt() {
-  bool rtrvInvalid = LinkedList<T>::itrtrReset_ || LinkedList<T>::wasTopRmvd_;
-  assert(rtrvInvalid || LinkedList<T>::rtrvEntry_ != NULL);
+  assert(LinkedList<T>::itrtrReset_ || LinkedList<T>::rtrvEntry_ != NULL);
 
-  if (rtrvInvalid) {
+  if (LinkedList<T>::itrtrReset_) {
     LinkedList<T>::rtrvEntry_ = LinkedList<T>::topEntry_;
-    LinkedList<T>::wasTopRmvd_ = false;
   } else {
     LinkedList<T>::rtrvEntry_ = LinkedList<T>::rtrvEntry_->GetNext();
   }
@@ -813,12 +818,9 @@ inline T *PriorityList<T, K>::GetNxtPriorityElmnt() {
 
 template <class T, class K>
 inline T *PriorityList<T, K>::GetNxtPriorityElmnt(K &key) {
-  bool rtrvInvalid = LinkedList<T>::itrtrReset_ || LinkedList<T>::wasTopRmvd_;
-  assert(rtrvInvalid || LinkedList<T>::rtrvEntry_ != NULL);
-
-  if (rtrvInvalid) {
+  assert(LinkedList<T>::itrtrReset_ || LinkedList<T>::rtrvEntry_ != NULL);
+  if (LinkedList<T>::itrtrReset_) {
     LinkedList<T>::rtrvEntry_ = LinkedList<T>::topEntry_;
-    LinkedList<T>::wasTopRmvd_ = false;
   } else {
     LinkedList<T>::rtrvEntry_ = LinkedList<T>::rtrvEntry_->GetNext();
   }
@@ -836,24 +838,32 @@ inline T *PriorityList<T, K>::GetNxtPriorityElmnt(K &key) {
 template <class T, class K>
 inline void PriorityList<T, K>::getRemainingElmnts(LinkedList<T> *fillList) {
   if (LinkedList<T>::rtrvEntry_ == NULL) {
+    //Logger::Info("rtrvEntryNull");
     if (LinkedList<T>::itrtrReset_) {
       LinkedList<T>::rtrvEntry_ = LinkedList<T>::topEntry_;
       LinkedList<T>::itrtrReset_ = false;
-    } else if (LinkedList<T>::wasTopRmvd_) {
+    }
+    else if (LinkedList<T>::wasTopRmvd_) {
       LinkedList<T>::rtrvEntry_ = LinkedList<T>::topEntry_;
       LinkedList<T>::wasTopRmvd_ = false;
-    } else {
+    }
+    else {
+      //Logger::Info("!itrtrReset");
       return;
     }
+      
   }
 
   Entry<T> *temp = LinkedList<T>::rtrvEntry_;
   if (temp != NULL) temp = temp->GetNext();
   while (temp != NULL) {
+    //Logger::Info("inserting %d into list", temp->element);
     fillList->InsrtElmnt(temp->element);
     temp = temp->GetNext();
   }
 }
+
+
 
 //(Vlad) added functionality to decrease priority
 // used for decreasing priority of clusterable instrs
@@ -933,15 +943,12 @@ void PriorityList<T, K>::CopyList(
     if (!keyedEntries_.empty()) {
       const auto elementNum = entry->element->GetNum();
       assert(0 <= elementNum);
-#if DEBUG_LOG_TYPE
-      if (static_cast<size_t>(elementNum) >= keyedEntries_.size()) {
-        Logger::Info("elementNum %d", elementNum);
-        Logger::Info("keyedEntries_.size() %d", keyedEntries_.size());
-      }
-      Logger::Info("keyedEntires_.size() %d", keyedEntries_.size());
-      Logger::Info("elementNum %d", elementNum);
-#endif
-
+      //if (static_cast<size_t>(elementNum) >= keyedEntries_.size()) {
+      //  Logger::Info("elementNum %d", elementNum);
+      //  Logger::Info("keyedEntries_.size() %d", keyedEntries_.size());
+      //}
+      //Logger::Info("keyedEntires_.size() %d", keyedEntries_.size());
+      //Logger::Info("elementNum %d", elementNum);
       assert(static_cast<size_t>(elementNum) < keyedEntries_.size());
       keyedEntries_[elementNum] = newEntry;
     }

--- a/lib/Scheduler/bb_thread.cpp
+++ b/lib/Scheduler/bb_thread.cpp
@@ -1353,6 +1353,7 @@ FUNC_RESULT BBWithSpill::Enumerate_(Milliseconds StartTime,
       timeout = true;
     HandlEnumrtrRslt_(rslt, trgtLngth);
 
+   
 
     if (getBestCost() == 0 || rslt == RES_ERROR ||
         rslt == RES_TIMEOUT ||

--- a/lib/Scheduler/machine_model.cpp
+++ b/lib/Scheduler/machine_model.cpp
@@ -100,10 +100,7 @@ InstType MachineModel::GetInstTypeByName(llvm::StringRef typeName,
       return (InstType)i;
     }
   }
-#if DEBUG_LOG_TYPE
-  Logger::Error("Unrecognized instruction type %s.", typeName.str());
-#endif
-
+  //  Logger::Error("Unrecognized instruction type %s.", typeName.c_str());
   return INVALID_INST_TYPE;
 }
 
@@ -115,19 +112,8 @@ int16_t MachineModel::GetRegTypeByName(const char *const regTypeName) const {
       break;
     }
   }
-
-#if DEBUG_LOG_TYPE
-  // Register information log/debug
-  std::string registerString = "[ ";
-  for (auto regType : registerTypes_) {
-    registerString += regType.name + " ";
-  }
-  registerString += "]";
-  Logger::Info("Register types: %s", registerString.c_str());
-  Logger::Info("Register type: %d, %s", Type, regTypeName);
-#endif
-
-  assert(Type != INVALID_VALUE && "No register type with that name in machine model");
+  assert(Type != INVALID_VALUE &&
+         "No register type with that name in machine model");
   return Type;
 }
 

--- a/lib/Scheduler/ready_list.cpp
+++ b/lib/Scheduler/ready_list.cpp
@@ -12,11 +12,10 @@ ReadyList::ReadyList() {
   latestSubLst_ = *(new LinkedList<SchedInstruction>(INVALID_VALUE));
 }*/
 
-ReadyList::ReadyList(DataDepGraph *dataDepGraph, SchedPriorities prirts,
-                     int SolverID) {
+ReadyList::ReadyList(DataDepGraph *dataDepGraph, SchedPriorities prirts, int SolverID) {
   isFull_ = true;
   SolverID_ = SolverID;
-
+  
   prirts_ = prirts;
   int i;
   uint16_t totKeyBits = 0;
@@ -125,10 +124,7 @@ ReadyList::ReadyList(DataDepGraph *dataDepGraph, SchedPriorities prirts,
   }
 }
 
-ReadyList::~ReadyList() {
-  if (isFull_)
-    Reset();
-}
+ReadyList::~ReadyList() { if (isFull_) Reset(); }
 
 void ReadyList::Reset() {
   prirtyLst_.Reset();
@@ -205,7 +201,7 @@ unsigned long ReadyList::CmputKey_(SchedInstruction *inst, bool isUpdate,
 void ReadyList::AddLatestSubLists(LinkedList<SchedInstruction> *lst1,
                                   LinkedList<SchedInstruction> *lst2,
                                   BBThread *rgn) {
-  // FIXME: assert(latestSubLst_.GetElmntCnt() == 0);
+  //assert(latestSubLst_.GetElmntCnt() == 0);
   if (lst1 != NULL)
     AddLatestSubList_(lst1, rgn);
   if (lst2 != NULL)
@@ -224,8 +220,7 @@ void ReadyList::Print(std::ostream &out) {
   prirtyLst_.ResetIterator();
 }
 
-void ReadyList::AddLatestSubList_(LinkedList<SchedInstruction> *lst,
-                                  BBThread *rgn) {
+void ReadyList::AddLatestSubList_(LinkedList<SchedInstruction> *lst, BBThread *rgn) {
   assert(lst != NULL);
 
 #ifdef IS_DEBUG_READY_LIST2
@@ -262,6 +257,7 @@ void ReadyList::RemoveLatestSubList() {
 
   for (SchedInstruction *inst = latestSubLst_.GetFrstElmnt(); inst != NULL;
        inst = latestSubLst_.GetNxtElmnt()) {
+    //assert(inst->IsInReadyList(SolverID_));
     inst->RemoveFromReadyList(SolverID_);
 #ifdef IS_DEBUG_READY_LIST2
     Logger::GetLogStream() << inst->GetNum() << ", ";
@@ -304,6 +300,7 @@ SchedInstruction *ReadyList::viewNextPriorityInst() {
   return prirtyLst_.ViewNxtPriorityElmnt();
 }
 
+
 SchedInstruction *ReadyList::GetNextPriorityInst() {
   return prirtyLst_.GetNxtPriorityElmnt();
 }
@@ -319,18 +316,18 @@ void ReadyList::UpdatePriorities(BBThread *rgn) {
   bool instChanged = false;
   for (inst = prirtyLst_.GetFrstElmnt(); inst != NULL;
        inst = prirtyLst_.GetNxtElmnt()) {
-
     unsigned long key = CmputKey_(inst, true, instChanged, rgn);
     if (instChanged) {
-
       prirtyLst_.BoostEntry(keyedEntries_[inst->GetNum()], key);
     }
   }
 }
 
-void ReadyList::GetUnscheduledInsts(
-    LinkedList<SchedInstruction> *unscheduledInsts) {
+void ReadyList::GetUnscheduledInsts(LinkedList<SchedInstruction> *unscheduledInsts) {
+  //Logger::Info("getting unscheduld insts from prirtyLst");
   prirtyLst_.getRemainingElmnts(unscheduledInsts);
+  //Logger::Info("size of fillList %d", unscheduledInsts->GetElmntCnt());
+  //Logger::Info("finished getting unscheduld insts from prirtyLst");
 }
 
 void ReadyList::RemoveNextPriorityInst() { prirtyLst_.RmvCrntElmnt(); }
@@ -338,6 +335,7 @@ void ReadyList::RemoveNextPriorityInst() { prirtyLst_.RmvCrntElmnt(); }
 void ReadyList::RemoveSpecificInst(SchedInstruction *removeInst) {
   prirtyLst_.RmvElmnt(removeInst, false);
 }
+
 
 bool ReadyList::FindInst(SchedInstruction *inst, int &hitCnt) {
   return prirtyLst_.FindElmnt(inst, hitCnt);

--- a/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
+++ b/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
@@ -144,11 +144,10 @@ void OptSchedGCNTarget::dumpOccupancyInfo(const InstSchedule *Schedule) const {
   const InstCount *PRP;
   Schedule->GetPeakRegPressures(PRP);
 
-  // Hardcoded register names from build/lib/Target/AMDGPU/AMDGPUGenRegisterInfo.inc::getRegPressureSetName
-  unsigned SGPR32Count = PRP[MM->GetRegTypeByName("SReg_32")] + GPRErrorMargin;
+  unsigned SGPR32Count = PRP[MM->GetRegTypeByName("SGPR32")] + GPRErrorMargin;
   auto MaxOccSGPR = ST->getOccupancyWithNumSGPRs(SGPR32Count);
 
-  unsigned VGPR32Count = PRP[MM->GetRegTypeByName("VGPR_32")] + GPRErrorMargin;
+  unsigned VGPR32Count = PRP[MM->GetRegTypeByName("VGPR32")] + GPRErrorMargin;
   auto MaxOccVGPR = ST->getOccupancyWithNumVGPRs(VGPR32Count);
   auto Occ = std::min(std::min(MaxOccSGPR, MaxOccVGPR), MaxOccLDS);
 

--- a/lib/Wrapper/OptSchedMachineWrapper.cpp
+++ b/lib/Wrapper/OptSchedMachineWrapper.cpp
@@ -13,7 +13,7 @@ Description:  A wrapper that convert an LLVM target to an OptSched MachineModel.
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/MC/MCInstrItineraries.h"
-#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Target/TargetMachine.h"
 #include <memory>
 
@@ -99,15 +99,13 @@ void OptSchedMachineModel::convertMachineModel(
   registerTypes_.clear();
 
   if (mdlName_ == "amdgcn") {
-
-    // Hardcoded register names from build/lib/Target/AMDGPU/AMDGPUGenRegisterInfo.inc::getRegPressureSetName
     RegTypeInfo SGPR32;
-    SGPR32.name = "SReg_32";
+    SGPR32.name = "SGPR32";
     SGPR32.count = 80;
     registerTypes_.push_back(SGPR32);
 
     RegTypeInfo VGPR32;
-    VGPR32.name = "VGPR_32";
+    VGPR32.name = "VGPR32";
     VGPR32.count = 24;
     registerTypes_.push_back(VGPR32);
   } else {

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -908,7 +908,7 @@ int ScheduleDAGOptSched::parseGlobalPoolSort() const {
   }
 
     llvm::report_fatal_error(
-      llvm::StringRef("Unrecognized option for GLOBAL_POOL_SORT setting: " + name), false);
+      "Unrecognized option for GLOBAL_POOL_SORT setting: " + name, false);
 
 }
 
@@ -933,7 +933,7 @@ SPILL_COST_FUNCTION ScheduleDAGOptSched::parseSpillCostFunc() const {
   }
 
   llvm::report_fatal_error(
-      llvm::StringRef("Unrecognized option for SPILL_COST_FUNCTION setting: " + name), false);
+      "Unrecognized option for SPILL_COST_FUNCTION setting: " + name, false);
 }
 
 
@@ -958,7 +958,7 @@ SPILL_COST_FUNCTION ScheduleDAGOptSched::parseGlobalPoolSpillCostFunc() const {
   }
 
   llvm::report_fatal_error(
-      llvm::StringRef("Unrecognized option for SPILL_COST_FUNCTION setting: " + name), false);
+      "Unrecognized option for SPILL_COST_FUNCTION setting: " + name, false);
 }
 
 
@@ -995,7 +995,7 @@ bool ScheduleDAGOptSched::shouldPrintSpills() const {
   }
 
   llvm::report_fatal_error(
-      llvm::StringRef("Unrecognized option for PRINT_SPILL_COUNTS setting: " + printSpills),
+      "Unrecognized option for PRINT_SPILL_COUNTS setting: " + printSpills,
       false);
 }
 


### PR DESCRIPTION
This reverts commit 6f3c68cbe8df98237495a871335aa922d5dc4f1f. This commit added rocm5 compatibility changes, which isn't currently being worked on. The intent is to revert those changes, and merge the linked list and history prune fixes separately.